### PR TITLE
Rename cardinality to unique as an operation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -424,11 +424,11 @@ The results look like this:
 
 We have not covered all the methods Lexus provides in this tutorial. The current list is:
 
-- find
-- count
-- cardinality
 - avg
+- count
+- find
 - max
 - min
 - sum
+- unique
 

--- a/schema/dev/schema.yml
+++ b/schema/dev/schema.yml
@@ -37,14 +37,6 @@ properties:
         properties:
           method:
             type: string
-            const: cardinality
-          params:
-            type: object
-      - required:
-        - field
-        properties:
-          method:
-            type: string
             const: count
           params:
             type: object
@@ -110,6 +102,14 @@ properties:
           method:
             type: string
             const: sum
+          params:
+            type: object
+      - required:
+        - field
+        properties:
+          method:
+            type: string
+            const: unique
           params:
             type: object
   filters:

--- a/suite/queries/query.cardinalityOrMatch.json
+++ b/suite/queries/query.cardinalityOrMatch.json
@@ -1,6 +1,0 @@
-{
-  "testId": "cardinalityOrMatch",
-  "description": "count the number of possible sensor.battery values that are in 'humidity.sensor.reading' or 'wind.sensor.reading' events",
-  "query": [{"version": "0.2", "invoke": {"method": "cardinality", "field": "sensor.battery"}, "filters": {"$or": [{"$match": {"event": "humidity.sensor.reading"}}, {"$match": {"event": "wind.sensor.reading"}}]}}],
-  "result": [{"version":"0.2","result":35}]
-}

--- a/suite/queries/query.uniqueOrMatch.json
+++ b/suite/queries/query.uniqueOrMatch.json
@@ -1,0 +1,6 @@
+{
+  "testId": "uniqueOrMatch",
+  "description": "count the number of possible sensor.battery values that are in 'humidity.sensor.reading' or 'wind.sensor.reading' events",
+  "query": [{"version": "0.2", "invoke": {"method": "unique", "field": "sensor.battery"}, "filters": {"$or": [{"$match": {"event": "humidity.sensor.reading"}}, {"$match": {"event": "wind.sensor.reading"}}]}}],
+  "result": [{"version":"0.2","result":35}]
+}


### PR DESCRIPTION
This fixes #12.

This renames the "cardinality" operation to "unique" as it's a more obvious in non-mathematical terms. I also changed the tests to load queries automatically, because otherwise we'll have to update file names constantly when changing the specification.