### PR TITLE
Remove 'field' as a requirement for count queries

### DIFF
--- a/schema/dev/schema.yml
+++ b/schema/dev/schema.yml
@@ -32,9 +32,7 @@ properties:
             const: avg
           params:
             type: object
-      - required:
-        - field
-        properties:
+      - properties:
           method:
             type: string
             const: count


### PR DESCRIPTION
This fixes #18.

The `count` method will no longer require a field and instead operate on the document as an entity.